### PR TITLE
WIP: add support for M2M changed signal

### DIFF
--- a/easyaudit/models.py
+++ b/easyaudit/models.py
@@ -8,10 +8,15 @@ class CRUDEvent(models.Model):
     CREATE = 1
     UPDATE = 2
     DELETE = 3
+    M2M_CHANGE = 4
+    M2M_CHANGE_REV = 5
+
     TYPES = (
         (CREATE, 'Create'),
         (UPDATE, 'Update'),
         (DELETE, 'Delete'),
+        (M2M_CHANGE, 'Many-to-Many Change'),
+        (M2M_CHANGE_REV, 'Reverse Many-to-Many Change'),
     )
 
     event_type = models.SmallIntegerField(choices=TYPES)

--- a/easyaudit/signals.py
+++ b/easyaudit/signals.py
@@ -124,6 +124,7 @@ def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwarg
 
             tmp_repr[0]['m2m_rev_model'] = force_text(model._meta)
             tmp_repr[0]['m2m_rev_pks'] = related_ids
+            tmp_repr[0]['m2m_rev_action'] = action
             object_json_repr = json.dumps(tmp_repr)
         else:
             event_type = CRUDEvent.M2M_CHANGE

--- a/easyaudit/signals.py
+++ b/easyaudit/signals.py
@@ -94,6 +94,16 @@ def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwarg
             event_type = CRUDEvent.M2M_CHANGE_REV
         else:
             event_type = CRUDEvent.M2M_CHANGE
+
+        # user
+        try:
+            user = get_current_user()
+        except:
+            user = None
+
+        if isinstance(user, AnonymousUser):
+            user = None
+
     except Exception:
         logger.exception('easy audit had an m2m-changed exception.')
     pass

--- a/easyaudit/signals.py
+++ b/easyaudit/signals.py
@@ -85,6 +85,9 @@ def post_save(sender, instance, created, raw, using, update_fields, **kwargs):
 def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwargs):
 
     try:
+        if not should_audit(instance):
+            return False
+
         if reverse:
             event_type = CRUDEvent.M2M_CHANGE_REV
         else:

--- a/easyaudit/signals.py
+++ b/easyaudit/signals.py
@@ -118,7 +118,6 @@ def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwarg
         crud_event.save()
     except Exception:
         logger.exception('easy audit had an m2m-changed exception.')
-    pass
 
 
 def post_delete(sender, instance, using, **kwargs):

--- a/easyaudit/signals.py
+++ b/easyaudit/signals.py
@@ -82,6 +82,10 @@ def post_save(sender, instance, created, raw, using, update_fields, **kwargs):
         logger.exception('easy audit had a post-save exception.')
 
 
+def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwargs):
+    pass
+
+
 def post_delete(sender, instance, using, **kwargs):
     """https://docs.djangoproject.com/es/1.10/ref/signals/#post-delete"""
     try:
@@ -143,6 +147,7 @@ def user_login_failed(sender, credentials, **kwargs):
 
 
 models_signals.post_save.connect(post_save, dispatch_uid='easy_audit_signals_post_save')
+models_signals.m2m_changed.connect(m2m_changed, dispatch_uid='easy_audit_signals_m2m_changed')
 models_signals.post_delete.connect(post_delete, dispatch_uid='easy_audit_signals_post_delete')
 
 if WATCH_LOGIN_EVENTS:

--- a/easyaudit/signals.py
+++ b/easyaudit/signals.py
@@ -88,6 +88,9 @@ def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwarg
         if not should_audit(instance):
             return False
 
+        if action not in ("post_add", "post_remove", "post_clear"):
+            return False
+
         object_json_repr = serializers.serialize("json", [instance])
 
         if reverse:

--- a/easyaudit/signals.py
+++ b/easyaudit/signals.py
@@ -104,6 +104,18 @@ def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwarg
         if isinstance(user, AnonymousUser):
             user = None
 
+        crud_event = CRUDEvent.objects.create(
+            event_type=event_type,
+            object_repr=str(instance),
+            object_json_repr=object_json_repr,
+            content_type=ContentType.objects.get_for_model(instance),
+            object_id=instance.id,
+            user=user,
+            datetime=timezone.now(),
+            user_pk_as_string=str(user.pk) if user else user
+        )
+
+        crud_event.save()
     except Exception:
         logger.exception('easy audit had an m2m-changed exception.')
     pass

--- a/easyaudit/signals.py
+++ b/easyaudit/signals.py
@@ -83,6 +83,14 @@ def post_save(sender, instance, created, raw, using, update_fields, **kwargs):
 
 
 def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwargs):
+
+    try:
+        if reverse:
+            event_type = CRUDEvent.M2M_CHANGE_REV
+        else:
+            event_type = CRUDEvent.M2M_CHANGE
+    except Exception:
+        logger.exception('easy audit had an m2m-changed exception.')
     pass
 
 

--- a/easyaudit/signals.py
+++ b/easyaudit/signals.py
@@ -83,7 +83,7 @@ def post_save(sender, instance, created, raw, using, update_fields, **kwargs):
 
 
 def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwargs):
-
+    """https://docs.djangoproject.com/es/1.10/ref/signals/#m2m-changed"""
     try:
         if not should_audit(instance):
             return False

--- a/easyaudit/signals.py
+++ b/easyaudit/signals.py
@@ -88,6 +88,8 @@ def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwarg
         if not should_audit(instance):
             return False
 
+        object_json_repr = serializers.serialize("json", [instance])
+
         if reverse:
             event_type = CRUDEvent.M2M_CHANGE_REV
         else:


### PR DESCRIPTION
This pull request adds M2M support to the django-easy-audit log. 

Fun fact: part of this PR has already been acknowledged by the upstream project, because I accidentally used their master as the base branch. (See https://github.com/soynatan/django-easy-audit/pull/20). I think they will merge it now that it's complete.

@amykyta, let's talk about this in person. The current design has a problem that i want to show you.

## Example M2M log

The table below shows what gets logged after you run the following code:

```
b = Business.objects.get(id=3)
b.users.add(User.objects.get(id=55))
b.users.add(User.objects.get(id=56))
b.users.clear()
```

(some irrelevant fields omitted, relevant fields in bold)

| id  | event_type | object_id | object_repr | object_json_repr | datetime |
| --- | --- | --- | --- | --- | --- |
| 548 |          4 |         4 | Business object | [{"model": "apply.business", "pk": 4, "fields": {"business_name": "Katrina's Business 4", **"users": [55]**}}]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 2017-07-06 15:42:54 |
| 549 |          4 |         4 | Business object | [{"model": "apply.business", "pk": 4, "fields": {"business_name": "Katrina's Business 4", **"users": [55, 56]**}}]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | 2017-07-06 15:42:56 |
| 550 |          4 |         4 | Business object | [{"model": "apply.business", "pk": 4, "fields": {"business_name": "Katrina's Business 4", **"users": []**}}]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 2017-07-06 15:42:59 |

## Example reversed M2M log

```
u = User.objects.get(id=55)
u.business_set.add(Business.objects.get(id=3))
u.business_set.add(Business.objects.get(id=4))
u.business_set.clear()
```
(some irrelevant fields omitted, new fields in bold)

| id  | event_type | object_id | object_repr | object_json_repr | datetime |
| --- | --- | --- | --- | --- | --- |
| 567 |          5 |        55 | test@bondstreet.com        | [{"pk": 55, "model": "accounts.user", **"m2m_rev_model": "apply.business", "m2m_rev_changed_pks": [3]**, "fields": {"first_name": "Katrina", "last_name": "Test", "email": "test@bondstreet.com", "date_joined": "2017-03-28T16:15:22Z"}}]                                                                                                                                                             | 2017-07-06 15:58:53 |
| 568 |          5 |        55 | test@bondstreet.com        | [{"pk": 55, "model": "accounts.user", **"m2m_rev_model": "apply.business", "m2m_rev_changed_pks": [4]**, "fields": {"first_name": "Katrina", "last_name": "Test", "email": "test@bondstreet.com", "date_joined": "2017-03-28T16:15:22Z"}}]                                                                                                                                                             | 2017-07-06 15:59:02 |
| 569 |          5 |        55 | test@bondstreet.com        | [{"pk": 55, "model": "accounts.user", **"m2m_rev_model": "apply.business", "m2m_rev_changed_pks": []**, "fields": {"first_name": "Katrina", "last_name": "Test", "email": "test@bondstreet.com", "date_joined": "2017-03-28T16:15:22Z"}}]                                                                                                                                                              | 2017-07-06 15:59:14 |