### PR TITLE
Clear out `_thread_locals.request`

### DIFF
--- a/easyaudit/middleware/easyaudit.py
+++ b/easyaudit/middleware/easyaudit.py
@@ -32,3 +32,17 @@ class EasyAuditMiddleware(MiddlewareMixin):
     def process_request(self, request):
         _thread_locals.request = request
         return None
+
+    def process_response(self, request, response):
+        try:
+            del _thread_locals.request
+        except AttributeError:
+            pass
+        return response
+
+    def process_exception(self, request, exception):
+        try:
+            del _thread_locals.request
+        except AttributeError:
+            pass
+        return None


### PR DESCRIPTION
@amykyta @hjc - Between this pull request and #2, I have the full test suite working properly (if run with `--nomigrations`) on my VM.

We still need to fix the problems with migrations before this is ready to deploy. The biggest problem is that easyaudit wants to log everything that happens during migrations, even before the `easyaudit_crudevent` table exists. We need to either turn off easyaudit logging during migrations (not preferred because data migrations contain important info that should be logged, but maybe OK if it's only in the test environment) or figure out how to force the `create table easyaudit_crudevent` migration to run before anything else.