### PR TITLE
Add run-before statement to migration 0005

### DIFF
--- a/easyaudit/migrations/0005_auto_20170713_1155.py
+++ b/easyaudit/migrations/0005_auto_20170713_1155.py
@@ -11,6 +11,10 @@ class Migration(migrations.Migration):
         ('easyaudit', '0004_auto_20170620_1354'),
     ]
 
+    run_before = [
+       ('apply', '0001_initial'),
+    ]
+
     operations = [
         migrations.AlterField(
             model_name='crudevent',


### PR DESCRIPTION
This is one possible approach to making our tests pass with easy-audit installed. Without this fix, easy-audit causes problems because it attempts to log CRUD events that happen during migrations. If the easy-audit migrations haven't run yet, the `CRUDEvent` table will not exist, causing an error.

Possible solutions include:

1) Forcing easy-audit to create the `CRUDEvent` table before any other migrations are run (this is what this PR does). 

2) Modifying other apps' initial migrations so they run after easy-audit's migrations (i.e. adding something like

    ```
    dependencies = [
       ('easyaudit', '0005_auto_20170713_1155'),
    ]
    ```

    to the first migration in the `apply` app, and any other apps that do not play nicely with easy-audit during tests. (As of right now, `apply` is the only problem, but other apps will need to be added if we add data migrations to them). This is basically the same as (1), just with the dependency declared in a different place.

3) Turning easy-audit off during migrations. I don't think we should do this if we want a full record of what happened. We do data migrations on live production data, and those changes should be captured in the audit log.

4) Turning easy-audit off during tests. I don't think we should do this either, since we want the tests to notify us if easy-audit isn't playing nicely with our apps.

5) Turning easy-audit off during migrations during tests. This is a plausible solution, but I'm not sure how to do it.